### PR TITLE
feat: adding new option for providing PR number in action and removing unnecessary return statement in try/catch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,14 @@ This action overwrites the pr body. Useful for when you want to append informati
 
 **Required** Github token
 
+## `pr_number`
+
+**optional** PR number which we want to update
+
 ## Example usage
 
     uses: AsasInnab/pr-body-action@v1
     with:
-    	body: "This is my new PR body :)"
-    	GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        body: "This is my new PR body :)"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        pr_number: 2137

--- a/index.js
+++ b/index.js
@@ -8,13 +8,13 @@ try {
   const providedPrNumber = core.getInput("pr_number");
 
   if (context.payload.pull_request == null) {
-    core.setFailed("No pull request found");
+    throw new Error("No pull request found");
   }
   if (!githubToken) {
-    core.setFailed("GITHUB_TOKEN input is required");
+    throw new Error("GITHUB_TOKEN input is required");
   }
   if (!body) {
-    core.setFailed("body input is required");
+    throw new Error("body input is required");
   }
 
   const { number: currentPrNumber } = context.payload.pull_request;

--- a/index.js
+++ b/index.js
@@ -5,26 +5,26 @@ try {
   const { context } = github;
   const githubToken = core.getInput("GITHUB_TOKEN");
   const body = core.getInput("body");
+  const providedPrNumber = core.getInput("pr_number");
 
   if (context.payload.pull_request == null) {
     core.setFailed("No pull request found");
-    return;
   }
   if (!githubToken) {
     core.setFailed("GITHUB_TOKEN input is required");
-    return;
   }
   if (!body) {
     core.setFailed("body input is required");
-    return;
   }
 
-  const { number: prNumber } = context.payload.pull_request;
+  const { number: currentPrNumber } = context.payload.pull_request;
+  const prNumber = providedPrNumber || currentPrNumber;
+
   const octokit = new github.GitHub(githubToken);
   octokit.pulls.update({
     ...context.repo,
     pull_number: prNumber,
-    body
+    body,
   });
 } catch (error) {
   core.setFailed(error.message);


### PR DESCRIPTION
This pull request adds a new option for providing the Pull Request number in the action. This will allow users to easily specify which PR the action should run on. The new option is implemented as an _optional_ parameter called `pr_number` that can be passed to the action.

Additionally, this pull request removes an unnecessary `return` statement and `core.setFailed` method call in a `try/catch` block in the JavaScript code. The `return` statement is only applicable for functions, and its presence in the block can cause confusion and potential issues for developers. Removing this statement simplifies the code and makes it more consistent with JavaScript best practices. Core's `setFailed` method is catching errors already, so throwing error will be more sufficient. More about why I choose it [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling#exception_handling_statements).

Thank you for considering this pull request.

---

P.S. for consideration:
- bundle node_modules and only used modules to one js
- remove node_modules
   - add node_modules to .gitignote